### PR TITLE
added rules 3.1.14 and 3.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Make sure to read [Apple's API Design Guidelines](https://swift.org/documentatio
 
 Specifics from these guidelines + additional remarks are mentioned below.
 
-This guide was last updated for Swift 2.2 on August 17th, 2016.
+This guide was last updated for Swift 2.2 on August 27th, 2016.
 
 ## Table Of Contents
 
@@ -469,6 +469,9 @@ do {
 }
 ```
 
+* **3.1.14** Prefer `static` to `class` when declaring a function that is associated with a class as opposed to an instance of that class. Only use `class` if you specifically need the functionality of overriding that function in a subclass, though consider using a `protocol` to achieve this instead.
+
+* **3.1.15** If you have a function that takes no arguments, has no side effects, and returns some object or value, prefer using a computed property instead.
 
 ### 3.2 Access Modifiers
 


### PR DESCRIPTION
See diff for new rules.

Preferring `static` to `class` for several reasons:
1. Static dispatch is technically faster than dynamic dispatch
2. Given the above, it makes sense to pick `static` over `class` so that we consistently use one over the other.
3. This way, usage of `class` will indicate that the intent of that function is to be overridden, which can be useful information at-a-glance.
