### PR TITLE
Updated syntax for 3.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,21 +631,24 @@ var computedProperty: String {
 * **3.7.3** Though you can create a custom name for the new or old value for `willSet`/`didSet` and `set`, use the standard `newValue`/`oldValue` identifiers that are provided by default.
 
 ```swift
-var computedProperty: String {
-    get {
-        if someBool {
-            return "I'm a mighty pirate!"
-        }
-        return "I'm selling these fine leather jackets."
-    }
-    set {
-        computedProperty = newValue
-    }
+var storedProperty: String = "I'm selling these fine leather jackets." {
     willSet {
         print("will set to \(newValue)")
     }
     didSet {
-        print("did set from \(oldValue) to \(newValue)")
+        print("did set from \(oldValue) to \(storedProperty)")
+    }
+}
+
+var computedProperty: String  {
+    get {
+        if someBool {
+            return "I'm a mighty pirate!"
+        }
+        return storedProperty
+    }
+    set {
+        storedProperty = newValue
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Make sure to read [Apple's API Design Guidelines](https://swift.org/documentatio
 
 Specifics from these guidelines + additional remarks are mentioned below.
 
-This guide was last updated for Swift 2.2 on August 31st, 2016.
+This guide was last updated for Swift 2.2 on September 27th, 2016.
 
 ## Table Of Contents
 


### PR DESCRIPTION
The original example won't compile because computed properties can't have willSet/didSet. Also setting a computed property in its own setter throws a warning. This new code will compile (except for the someBool part)
