### PR TITLE
Fix inconsistencies in 3.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ In general, if a method can "fail", and the reason for the failure is not immedi
 ```swift
 // PREFERRED
 func eatDoughnut(at index: Int) {
-    guard index >= 0 && index < doughnuts else {
+    guard index >= 0 && index < doughnuts.count else {
         // return early because the index is out of bounds
         return
     }
@@ -824,8 +824,8 @@ func eatDoughnut(at index: Int) {
 }
 
 // NOT PREFERRED
-func eatDoughnuts(at index: Int) {
-    if index >= 0 && index < donuts.count {
+func eatDoughnut(at index: Int) {
+    if index >= 0 && index < doughnuts.count {
         let doughnut = doughnuts[index]
         eat(doughnut)
     }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Make sure to read [Apple's API Design Guidelines](https://swift.org/documentatio
 
 Specifics from these guidelines + additional remarks are mentioned below.
 
-This guide was last updated for Swift 3.0 on December 7th, 2016.
+This guide was last updated for Swift 3.0 on January 14th, 2017.
 
 ## Table Of Contents
 


### PR DESCRIPTION
- Change `doughnuts` to `doughnuts.count` as the former wouldn't have compiled
- Change `donuts` to `doughnuts` as the former was inconsistent
- Change the name of the second method from `eatDoughnuts(at:)` to `eatDoughnut(at:)` as the former was inconsistent and didn't make as much sense