### PR TITLE
Removing link for parameter doc syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ Guidelines:
 
 * **4.1.3** Do not prefix each additional line with a `*`.
 
-* **4.1.4** Use the new `- parameter` syntax as opposed to the old `:param:` syntax (make sure to use lower case `parameter` and not `Parameter`). Option-click on a method you wrote to make sure the quick help looks correct. See [the documentation on Swift Markup](https://developer.apple.com/library/watchos/documentation/Xcode/Reference/xcode_markup_formatting_ref/) for more details on how this is formatted.
+* **4.1.4** Use the new `- parameter` syntax as opposed to the old `:param:` syntax (make sure to use lower case `parameter` and not `Parameter`). Option-click on a method you wrote to make sure the quick help looks correct.
 
 ```swift
 class Human {


### PR DESCRIPTION
The linked URL to Apple documentation shows a style that we are choosing not to use. Since, we have an example and already link to the general Markup documentation, I have removed the specific parameter syntax one.