### PR TITLE
Fix fragment identifier in 1TBS links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This guide was last updated for Swift 3.0 on September 26th, 2017.
 * **1.2** Avoid uncomfortably long lines with a hard maximum of 160 characters per line (Xcode->Preferences->Text Editing->Page guide at column: 160 is helpful for this)
 * **1.3** Ensure that there is a newline at the end of every file.
 * **1.4** Ensure that there is no trailing whitespace anywhere (Xcode->Preferences->Text Editing->Automatically trim trailing whitespace + Including whitespace-only lines).
-* **1.5** Do not place opening braces on new lines - we use the [1TBS style](https://en.m.wikipedia.org/wiki/Indent_style#Variant:_1TBS).
+* **1.5** Do not place opening braces on new lines - we use the [1TBS style](https://en.m.wikipedia.org/wiki/Indentation_style#1TBS).
 
 ```swift
 class SomeClass {
@@ -459,7 +459,7 @@ imageView.backgroundColor = .white
 
 * **3.1.12** When writing methods, keep in mind whether the method is intended to be overridden or not. If not, mark it as `final`, though keep in mind that this will prevent the method from being overwritten for testing purposes. In general, `final` methods result in improved compilation times, so it is good to use this when applicable. Be particularly careful, however, when applying the `final` keyword in a library since it is non-trivial to change something to be non-`final` in a library as opposed to have changing something to be non-`final` in your local project.
 
-* **3.1.13** When using a statement such as `else`, `catch`, etc. that follows a block, put this keyword on the same line as the block. Again, we are following the [1TBS style](https://en.m.wikipedia.org/wiki/Indent_style#Variant:_1TBS) here. Example `if`/`else` and `do`/`catch` code is below.
+* **3.1.13** When using a statement such as `else`, `catch`, etc. that follows a block, put this keyword on the same line as the block. Again, we are following the [1TBS style](https://en.m.wikipedia.org/wiki/Indentation_style#1TBS) here. Example `if`/`else` and `do`/`catch` code is below.
 
 ```swift
 if someBoolean {


### PR DESCRIPTION
#### What does this PR do?

Fixes links to "1TBS" section on Wikipedia.

It looks like the canonical page name is now "Indentation_style", rather than "Indent_style" and the anchor is "1TBS", rather than "Variant:_1TBS".

Note: The existing links lead to the mobile version of Wikipedia, so I left them that way.

#### How should this be manually tested?

Click on the new links and verify that they lead to the correct section of the Wikipedia page.